### PR TITLE
rebranding project to Repo Flow

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,8 @@
-Reflow
+Repo Flow
 Copyright 2015 Ryan Lindeman
 
 This project can be found on GitHub at
-https://github.com/GatorQue/git-reflow
+https://github.com/GatorQue/git-repo-flow
 
 Repo
 Copyright (C) 2008 The Android Open Source Project

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# git-reflow
-Enhanced Google repo alternative that utilizes a git-flow methodology.
+# Repo Flow
+
+Repo Flow enhances the [Google Repo project](https://code.google.com/p/git-repo/) with a [git-flow](https://github.com/nvie/gitflow) branching model.
+
+The [git-flow](https://github.com/nvie/gitflow) branching model is applied at the manifest / composition as well as the Git project level. You can use this with any Git server, without the need for a [Gerrit Code Review](https://www.gerritcodereview.com/) server; Gerrit is a practical requirement to effectively use the [Google Repo tools](https://code.google.com/p/git-repo/).
+
+## Background
+
+Repo is a tool built on top of Git. It helps compose a number of Git projects into a single workspace, nicely solving repeatability issues. It was written to automate the Android Gerrit-centric development workflow. Repo however is of more generic value, which is why we created the Repo Flow enhancement. In absence of Gerrit, Repo can be used to compose a workspace from multiple Git repositories. Repo however lacks automation to update manifest files and support a git-flow branching model.
+
+Repo Flow therefore:
+
+1. Provides the git-flow operations at the composition and project level: 
+   * ```init```: Initialize the Repo project to support git-flow the branching model.
+   * ```feature```: Manage your feature branches.
+   * ```release```: Manage your release branches.
+   * ```hotfix```: Manage your hotfix branches.
+   * ```support```: Manage your support branches.
+1. Generates and merges manifests so that you can checkout and work on your feature, release, hotfix and support compositions.
+1. Generates release manifests for your tagged releases.


### PR DESCRIPTION
Hey Ryan,

This re-brands the project and adds a more complete project description. If you are okay with the changes, you can pull this and rename your project to git-repo-flow.

Regards,
Pieter
